### PR TITLE
fix(patch): [sc-3705] Connect to service with timeout.

### DIFF
--- a/Sources/DistributedSystem/DistributedSystemErrors.swift
+++ b/Sources/DistributedSystem/DistributedSystemErrors.swift
@@ -6,6 +6,7 @@ public enum DistributedSystemErrors: DistributedActorSystemError {
     case duplicatedEndpointIdentifier(EndpointIdentifier)
     case error(String)
     case connectionForActorLost(EndpointIdentifier)
+    case serviceDiscoveryTimeout(String)
 }
 
 public enum StreamErrors: DistributedActorSystemError {

--- a/Tests/DistributedSystemTests/DistributedSystemTests.swift
+++ b/Tests/DistributedSystemTests/DistributedSystemTests.swift
@@ -676,7 +676,7 @@ final class DistributedSystemTests: XCTestCase {
                     XCTFail("Should not be called")
                     return nil
                 },
-                deadline: DispatchTime.now().advanced(by: DispatchTimeInterval.seconds(2))
+                deadline: DispatchTime.now() + 2.0
             )
         } catch DistributedSystemErrors.serviceDiscoveryTimeout(let str) {
             XCTAssertEqual(str, TestServiceEndpoint.serviceName)

--- a/Tests/DistributedSystemTests/GenericDistributedActor.swift
+++ b/Tests/DistributedSystemTests/GenericDistributedActor.swift
@@ -41,7 +41,7 @@ final class GenericDistributedActorTests: XCTestCase {
     }
 
     func test1() async throws {
-        DistributedSystem.logger.logLevel = .debug
+        // DistributedSystem.logger.logLevel = .debug
 
         let processInfo = ProcessInfo.processInfo
         let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"


### PR DESCRIPTION
## Description

Add possibility to set a timeout for service discovery.

## How Has This Been Tested?

Unit and manual tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
