### PR TITLE
chore(patch): [sc-3758] Use logger internal metadata instead of external.

### DIFF
--- a/Sources/DistributedSystem/ChannelHandler.swift
+++ b/Sources/DistributedSystem/ChannelHandler.swift
@@ -23,7 +23,6 @@ class ChannelHandler: ChannelInboundHandler {
     }
 
     private var logger: Logger { DistributedSystem.logger }
-    private var logMetadata: Logger.Metadata? { actorSystem.logMetadata }
     private let side: Side
     private let actorSystem: DistributedSystem
 
@@ -43,7 +42,7 @@ class ChannelHandler: ChannelInboundHandler {
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         var buffer = unwrapInboundIn(data)
-        logger.trace("\(context.remoteAddressDescription): received \(buffer.readableBytes) bytes", metadata: logMetadata)
+        logger.trace("\(context.remoteAddressDescription): received \(buffer.readableBytes) bytes")
         actorSystem.channelRead(context, &buffer)
     }
 

--- a/Sources/DistributedSystem/DiscoveryManager.swift
+++ b/Sources/DistributedSystem/DiscoveryManager.swift
@@ -69,17 +69,13 @@ final class DiscoveryManager {
     }
 
     private var logger: Logger { DistributedSystem.logger }
-    private var logMetadataBox: Box<Logger.Metadata?>
-    private var logMetadata: Logger.Metadata? { logMetadataBox.value }
 
     private var lock = Lock()
     private var generation: Int = 0
     private var processes: [SocketAddress: ProcessInfo] = [:]
     private var discoveries: [String: DiscoveryInfo] = [:]
 
-    init(_ logMetadataBox: Box<Logger.Metadata?>) {
-        self.logMetadataBox = logMetadataBox
-    }
+    init() {}
 
     func discoverService(_ serviceName: String,
                          _ serviceFilter: @escaping DistributedSystem.ServiceFilter,
@@ -122,7 +118,7 @@ final class DiscoveryManager {
             return (discover, addresses, services)
         }
 
-        logger.debug("discoverService: '\(serviceName)' \(discover) \(addresses) \(services)", metadata: logMetadata)
+        logger.debug("discoverService: '\(serviceName)' \(discover) \(addresses) \(services)")
 
         for (serviceID, service, process) in services {
             let connectionLossHandler = connectionHandler(serviceID, service, process?.channel)
@@ -196,7 +192,7 @@ final class DiscoveryManager {
                 fatalError("Internal error: duplicated service \(serviceName)/\(serviceID)")
             }
 
-            logger.debug("addService: \(serviceName)/\(serviceID)", metadata: logMetadata)
+            logger.debug("addService: \(serviceName)/\(serviceID)")
             discoveryInfo.services[serviceID] = ServiceInfo(service, factory)
 
             var services = [(DistributedSystem.ServiceIdentifier, ConsulServiceDiscovery.Instance, DistributedSystem.ConnectionHandler)]()

--- a/Sources/DistributedSystem/DistributedSystemServer.swift
+++ b/Sources/DistributedSystem/DistributedSystemServer.swift
@@ -39,12 +39,8 @@ public class DistributedSystemServer: DistributedSystem {
             throw DistributedSystemErrors.error("Invalid local address (\(#file):\(#line))")
         }
 
-        if var logMetadata = logMetadataBox.value {
-            logMetadata["port"] = Logger.MetadataValue(stringLiteral: "\(portNumber)")
-            logMetadataBox.value = logMetadata
-        }
-
-        logger.debug("starting server '\(systemName)' @ \(portNumber)", metadata: logMetadata)
+        DistributedSystem.logger[metadataKey: "port"] = Logger.MetadataValue(stringLiteral: "\(portNumber)")
+        logger.debug("starting server '\(systemName)' @ \(portNumber)")
 
         // Ping service
         let metadata = [


### PR DESCRIPTION
## Description

Swift Logger has an internal metadata storage which simpler to use.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
