### PR TITLE
fix(patch): [sc-1690] Move dictionary serialisation test from DistributedSystemTests to TransferableConformanceTests

### DIFF
--- a/Sources/DistributedSystem/EndpointIdentifier.swift
+++ b/Sources/DistributedSystem/EndpointIdentifier.swift
@@ -1,3 +1,11 @@
+// Copyright 2023 Ordo One AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
 import NIOCore
 
 public struct EndpointIdentifier: Hashable, Codable, CustomStringConvertible {

--- a/Sources/DistributedSystem/InvocationEnvelope.swift
+++ b/Sources/DistributedSystem/InvocationEnvelope.swift
@@ -19,16 +19,16 @@ struct InvocationEnvelope {
     let genericSubstitutions: [Any.Type]
     let arguments: ByteBuffer
 
+    var size: UInt64 {
+        UInt64(MemoryLayout<Self>.size + targetFunc.count + arguments.readableBytes)
+    }
+
     private init(_ targetID: EndpointIdentifier, _ callID: UInt64, _ targetFunc: String, _ genericSubstitutions: [Any.Type], _ arguments: ByteBuffer) {
         self.targetID = targetID
         self.callID = callID
         self.targetFunc = targetFunc
         self.genericSubstitutions = genericSubstitutions
         self.arguments = arguments
-    }
-
-    var size: UInt64 {
-        UInt64(MemoryLayout<Self>.size + targetFunc.count + arguments.readableBytes)
     }
 
     init(from buffer: inout ByteBuffer) throws {

--- a/Sources/ForTesting/TestMessages/TestProtocols.swift
+++ b/Sources/ForTesting/TestMessages/TestProtocols.swift
@@ -3,7 +3,6 @@ public protocol TestableService {
     func getMonster() async -> Monster
     func doNothing() async
     func handleMonsters(_ monsters: [Monster]) async
-    func handleMonsters(_ monsters: [String: Monster]) async
 }
 
 public protocol TestableClient {

--- a/Sources/ForTesting/TestMessages/TestServiceEndpoint.swift
+++ b/Sources/ForTesting/TestMessages/TestServiceEndpoint.swift
@@ -30,8 +30,4 @@ public distributed actor TestServiceEndpoint: ServiceEndpoint {
     public distributed func handleMonsters(array monsters: [Monster]) async throws {
         await service.handleMonsters(monsters)
     }
-
-    public distributed func handleMonsters(dictionary monsters: [String: Monster]) async throws {
-        await service.handleMonsters(monsters)
-    }
 }

--- a/Tests/DistributedSystemTests/TransferableConformanceTests.swift
+++ b/Tests/DistributedSystemTests/TransferableConformanceTests.swift
@@ -2,7 +2,12 @@ import Distributed
 @testable import DistributedSystem
 @testable import DistributedSystemConformance
 import Frostflake
+@testable import TestMessages
 import XCTest
+
+fileprivate enum ServiceError: Error {
+    case error(String)
+}
 
 fileprivate distributed actor TestServiceEndpoint: ServiceEndpoint {
     public typealias ActorSystem = DistributedSystem
@@ -10,26 +15,77 @@ fileprivate distributed actor TestServiceEndpoint: ServiceEndpoint {
 
     static var serviceName: String { "TestActorService" }
 
+    private let stream: AsyncStream<Result<Void, Error>>
+    private let streamContinuation: AsyncStream<Result<Void, Error>>.Continuation
+
+    init(actorSystem: DistributedSystem, _ stream: AsyncStream<Result<Void, Error>>, _ streamContinuation: AsyncStream<Result<Void, Error>>.Continuation) {
+        self.actorSystem = actorSystem
+        self.stream = stream
+        self.streamContinuation = streamContinuation
+    }
+
     // test a distributed call with an array of transferable and trivially copyable objects (integers)
     public distributed func handleIntArray(_ data: [Int]) async {
+        var invalidEntries = 0
         for idx in 0..<data.count {
-            XCTAssertEqual(data[idx], idx)
+            if data[idx] != idx {
+                invalidEntries += 1
+            }
+        }
+        logger.info("SERVICE: got \(data.count) integers")
+        if invalidEntries == 0 {
+            streamContinuation.yield(.success(()))
+        } else {
+            streamContinuation.yield(.failure(ServiceError.error("Array has \(invalidEntries) invalid entries")))
         }
     }
 
     // test a distributed call with an array of transferable and trivially copyable objects (doubles)
     public distributed func handleDoubleArray(_ data: [Double]) async {
+        var invalidEntries = 0
         for idx in 0..<data.count {
-            XCTAssertEqual(data[idx], Double(idx))
+            if data[idx] != Double(idx) {
+                invalidEntries += 1
+            }
+        }
+        logger.info("SERVICE: got \(data.count) doubles")
+        if invalidEntries == 0 {
+            streamContinuation.yield(.success(()))
+        } else {
+            streamContinuation.yield(.failure(ServiceError.error("Array has \(invalidEntries) invalid entries")))
         }
     }
 
     // test a distributed call with an array of transferable objects
     public distributed func handleStringArray(_ data: [String]) async {
+        var invalidEntries = 0
         var str = ""
         for s in data {
-            XCTAssertEqual(s, str)
+            if s != str {
+                invalidEntries += 1
+            }
             str += "A"
+        }
+        logger.info("SERVICE: got \(data.count) strings")
+        if invalidEntries == 0 {
+            streamContinuation.yield(.success(()))
+        } else {
+            streamContinuation.yield(.failure(ServiceError.error("Array has \(invalidEntries) invalid entries")))
+        }
+    }
+
+    public distributed func handleMonsters(_ monsters: [String: Monster]) async {
+        var invalidEntries = 0
+        for key in monsters.keys {
+            if !key.hasPrefix("monster-") {
+                invalidEntries += 1
+            }
+        }
+        logger.info("SERVICE: got \(monsters.count) monsters")
+        if invalidEntries == 0 {
+            streamContinuation.yield(.success(()))
+        } else {
+            streamContinuation.yield(.failure(ServiceError.error("Dictionary has \(invalidEntries) invalid entries")))
         }
     }
 }
@@ -44,11 +100,15 @@ final class TransferableConformanceTests: XCTestCase {
         let processInfo = ProcessInfo.processInfo
         let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"
 
+        var streamContinuation: AsyncStream<Result<Void, Error>>.Continuation?
+        let stream = AsyncStream<Result<Void, Error>>() { streamContinuation = $0 }
+        guard let streamContinuation else { fatalError("Internal error: streamContinuation unexpectedly nil") }
+
         let moduleID = DistributedSystem.ModuleIdentifier(1)
         let serverSystem = DistributedSystemServer(name: systemName)
         try await serverSystem.start()
         try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
-            TestServiceEndpoint(actorSystem: actorSystem)
+            TestServiceEndpoint(actorSystem: actorSystem, stream, streamContinuation)
         }
 
         let clientSystem = DistributedSystem(name: systemName)
@@ -62,11 +122,78 @@ final class TransferableConformanceTests: XCTestCase {
         let intArray = (0...100).map { $0 }
         try await serviceEndpoint.handleIntArray(intArray)
 
+        for await result in stream {
+            if case let .failure(err) = result {
+                XCTFail(String(describing: err))
+            }
+            break
+        }
+
         let doubleArray = (0...150).map { Double($0) }
         try await serviceEndpoint.handleDoubleArray(doubleArray)
 
+        for await result in stream {
+            if case let .failure(err) = result {
+                XCTFail(String(describing: err))
+            }
+            break
+        }
+
         let stringArray = (0...200).map { String(repeating: "A", count: $0) }
         try await serviceEndpoint.handleStringArray(stringArray)
+
+        for await result in stream {
+            if case let .failure(err) = result {
+                XCTFail(String(describing: err))
+            }
+            break
+        }
+
+        clientSystem.stop()
+        serverSystem.stop()
+    }
+
+    func testDictionarySerialization() async throws {
+        let processInfo = ProcessInfo.processInfo
+        let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"
+
+        var streamContinuation: AsyncStream<Result<Void, Error>>.Continuation?
+        let stream = AsyncStream<Result<Void, Error>>() { streamContinuation = $0 }
+        guard let streamContinuation else { fatalError("Internal error: streamContinuation unexpectedly nil") }
+
+        let moduleID = DistributedSystem.ModuleIdentifier(1)
+        let serverSystem = DistributedSystemServer(name: systemName)
+        try await serverSystem.start()
+        try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
+            let serviceEndpoint = TestServiceEndpoint(actorSystem: actorSystem, stream, streamContinuation)
+            return (serviceEndpoint, nil)
+        }
+
+        let clientSystem = DistributedSystem(name: systemName)
+        try clientSystem.start()
+
+        let serviceEndpoint = try await clientSystem.connectToService(
+            TestServiceEndpoint.self,
+            withFilter: { _ in true },
+            serviceHandler: { _, _ in
+                return nil
+            }
+        )
+
+        var monsters = [String: Monster]()
+        for idx in 1...5 {
+            let monster = _MonsterStruct(identifier: MonsterIdentifier(idx))
+            monsters["monster-\(idx)"] = Monster(monster)
+        }
+
+        try await serviceEndpoint.handleMonsters(monsters)
+
+        for await result in stream {
+            if case let .failure(err) = result {
+                XCTFail(String(describing: err))
+            }
+            break
+        }
 
         clientSystem.stop()
         serverSystem.stop()


### PR DESCRIPTION
## Description

Array serialisation test is in the TransferableConformanceTests, so test for dictionary should be in the same place.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
