### PR TITLE
fix(patch): [sc-1690] Suspend distributed calls for the endpoing if inbound queue on the receiver side is big.

### DIFF
--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -1161,7 +1161,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
                 if (newSize < Self.endpointQueueLowWatermark) && (oldSize >= Self.endpointQueueLowWatermark) && ((oldState & Self.endpointQueueSuspendIndicator) != 0) {
                     newState -= Self.endpointQueueSuspendIndicator
                 }
-                let (exchanged, original) = queueState.compareExchange(expected: oldState, desired: newState, ordering: .releasing)
+                let (exchanged, original) = queueState.compareExchange(expected: oldState, desired: newState, ordering: .relaxed)
                 if exchanged {
                     if ((oldState & Self.endpointQueueSuspendIndicator) != 0) && ((newState & Self.endpointQueueSuspendIndicator) == 0) {
                         sendResumeEndpoint(envelope.targetID, to: channel)
@@ -1216,7 +1216,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
                 if (oldSize < Self.endpointQueueHighWatermark) && (newSize >= Self.endpointQueueHighWatermark) && ((oldState & Self.endpointQueueSuspendIndicator) == 0) {
                     newState |= Self.endpointQueueSuspendIndicator
                 }
-                let (exchanged, original) = res.queueState.compareExchange(expected: oldState, desired: newState, ordering: .releasing)
+                let (exchanged, original) = res.queueState.compareExchange(expected: oldState, desired: newState, ordering: .relaxed)
                 if exchanged {
                     if (oldSize < warningSize) && (newSize >= warningSize) {
                         // The warning threshold multiplied by 2 each time is breached,

--- a/Sources/DistributedSystem/DistributedSystemErrors.swift
+++ b/Sources/DistributedSystem/DistributedSystemErrors.swift
@@ -14,8 +14,9 @@ public enum DistributedSystemErrors: DistributedActorSystemError {
     case duplicatedService(String, DistributedSystem.ModuleIdentifier)
     case duplicatedEndpointIdentifier(EndpointIdentifier)
     case error(String)
-    case connectionForActorLost(EndpointIdentifier)
+    case noConnectionForActor(EndpointIdentifier)
     case serviceDiscoveryTimeout(String)
+    case connectionLost
 }
 
 public enum StreamErrors: DistributedActorSystemError {

--- a/Sources/DistributedSystem/DistributedSystemErrors.swift
+++ b/Sources/DistributedSystem/DistributedSystemErrors.swift
@@ -16,6 +16,7 @@ public enum DistributedSystemErrors: DistributedActorSystemError {
     case error(String)
     case noConnectionForActor(EndpointIdentifier)
     case serviceDiscoveryTimeout(String)
+    case unexpectedResultType(String)
     case connectionLost
 }
 

--- a/Sources/DistributedSystem/SyncCallManager.swift
+++ b/Sources/DistributedSystem/SyncCallManager.swift
@@ -93,7 +93,7 @@ class SyncCallManager {
         if let result = result as? T {
             return result
         } else {
-            throw DistributedSystemErrors.error("Result does not conform to \(T.self)")
+            throw DistributedSystemErrors.unexpectedResultType("\(type(of: result)) instead of \(T.self)")
         }
     }
 


### PR DESCRIPTION
## Description

Suspend distributed calls for the endpoing if inbound queue on the receiver side is big.

## How Has This Been Tested?

Unit and manual tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
