### PR TITLE
fix(patch): [sc-7847] Fix problem with message size for suspend/resume requests.

### DIFF
--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -1140,7 +1140,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
                     if !remoteClient.continuations.isEmpty {
                         logger.error("internal error: not suspended endpoint \(endpointID) has \(remoteClient.continuations.count) continuations")
                     }
-                    logger.debug("suspend enpoint \(endpointID)")
+                    logger.debug("suspend endpoint \(endpointID)")
                     remoteClient.suspended = true
                     self.actors[endpointID] = .remoteClient(remoteClient)
                 }
@@ -1156,7 +1156,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
                     self.actors[endpointID] = .remoteService(remoteService)
                 }
             default:
-                logger.error("internal error: suspend enpoint \(endpointID) \(actorInfo)")
+                logger.error("internal error: suspend endpoint \(endpointID) \(actorInfo)")
             }
         }
     }

--- a/Sources/DistributedSystem/EndpointIdentifier.swift
+++ b/Sources/DistributedSystem/EndpointIdentifier.swift
@@ -20,6 +20,11 @@ public struct EndpointIdentifier: Hashable, Codable, CustomStringConvertible {
         return "\(side):\(channelID):\(instanceID >> 1)"
     }
 
+    static func instanceIdentifierDescription(_ instanceID: InstanceIdentifier) -> String {
+        let side = ((instanceID & Self.serviceFlag) == 0) ? "C" : "S"
+        return "\(side):X:\(instanceID >> 1)"
+    }
+
     init(_ channelID: UInt32, _ instanceID: InstanceIdentifier) {
         self.channelID = channelID
         self.instanceID = instanceID


### PR DESCRIPTION
## Description

Fix problem with message size for suspend/resume requests.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
