### PR TITLE
fix(patch): [sc-7972] Log a warning message when channel outbound queue grow

### DIFF
--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -225,7 +225,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
                 channel.pipeline.addHandler(ByteToMessageHandler(StreamDecoder(self.loggerBox))).flatMap { _ in
-                    channel.pipeline.addHandler(ChannelHandler(self.nextChannelID, self, address))
+                    channel.pipeline.addHandler(ChannelHandler(self.nextChannelID, self, address, self.endpointQueueWarningSize))
                 }
             }
             .connect(to: address)

--- a/Sources/DistributedSystem/DistributedSystemServer.swift
+++ b/Sources/DistributedSystem/DistributedSystemServer.swift
@@ -32,7 +32,7 @@ public class DistributedSystemServer: DistributedSystem {
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 channel.pipeline.addHandler(ByteToMessageHandler(StreamDecoder(self.loggerBox))).flatMap { _ in
-                    channel.pipeline.addHandler(ChannelHandler(self.nextChannelID, self, nil))
+                    channel.pipeline.addHandler(ChannelHandler(self.nextChannelID, self, nil, self.endpointQueueWarningSize))
                 }
             }
             .bind(host: address.host, port: address.port)


### PR DESCRIPTION
## Description

Log a warning message when the channel's outbound queue size reach 1Mb, 2Mb, 4Mb etc.

## How Has This Been Tested?

Unit and manual tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
