### PR TITLE
chore(minor): add ability to specify log level for DistributedSystem [sc-1847]

### DIFF
--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -193,11 +193,11 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
     @TaskLocal
     private static var actorID: ActorID? // supposed to be private, but need to make it internal for tests
 
-    public convenience init(systemName: String) {
-        self.init(name: systemName)
+    public convenience init(systemName: String, logLevel: Logger.Level? = nil) {
+        self.init(name: systemName, logLevel: logLevel)
     }
 
-    public init(name: String) {
+    public init(name: String, logLevel: Logger.Level? = nil) {
         systemName = name
         eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         consul = Consul()
@@ -205,8 +205,10 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
         discoveryManager = DiscoveryManager(loggerBox)
         syncCallManager = SyncCallManager(loggerBox)
 
-        // loggerBox.value.logLevel = .debug
-        // consul.logLevel = .debug
+        if let logLevel {
+            loggerBox.value.logLevel = logLevel
+            consul.logLevel = logLevel
+        }
     }
 
     deinit {


### PR DESCRIPTION
## Description

Pass log level as an optional argument to `DistributedSystem` initializer.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
