### PR TITLE
fix(patch): [sc-8192] connectToService() throws specific error instead of generic string.

### DIFF
--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -552,7 +552,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
                 }
 
                 guard monitor.setValue(continuation) else {
-                    continuation.resume(throwing: DistributedSystemErrors.error("Cancelled"))
+                    continuation.resume(throwing: DistributedSystemErrors.cancelled("\(S.self)"))
                     return
                 }
 
@@ -573,14 +573,14 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
                 )
 
                 if !started {
-                    continuation.resume(throwing: DistributedSystemErrors.error("Cancelled"))
+                    continuation.resume(throwing: DistributedSystemErrors.cancelled("\(S.self)"))
                 }
             }
         } onCancel: {
             let continuation = monitor.cancel()
             if let continuation {
                 if cancellationToken.cancel() {
-                    continuation.resume(throwing: DistributedSystemErrors.error("Cancelled"))
+                    continuation.resume(throwing: DistributedSystemErrors.cancelled("\(S.self)"))
                 }
             }
         }

--- a/Sources/DistributedSystem/DistributedSystemErrors.swift
+++ b/Sources/DistributedSystem/DistributedSystemErrors.swift
@@ -18,6 +18,7 @@ public enum DistributedSystemErrors: DistributedActorSystemError {
     case connectionLost
     case unknownActor(EndpointIdentifier)
     case invalidActorState(String)
+    case cancelled(String)
 }
 
 public enum StreamErrors: DistributedActorSystemError {


### PR DESCRIPTION
## Description

connectToService() throws specific error instead of generic string.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
