### PR TITLE
fix(major): [sc-82] Move ModuleIdentifier from DistributedSystem type to the DistributedSystem module.

### DIFF
--- a/Benchmarks/DistributedSystem/DistributedSystemBenchmarks.swift
+++ b/Benchmarks/DistributedSystem/DistributedSystemBenchmarks.swift
@@ -68,7 +68,7 @@ let benchmarks = {
         let stream = AsyncStream<TestClientEndpoint>() { streamContinuation = $0 }
         var streamIterator = stream.makeAsyncIterator()
 
-        try await serviceSystem.addService(ofType: TestServiceEndpoint.self, toModule: DistributedSystem.ModuleIdentifier(1)) { actorSystem in
+        try await serviceSystem.addService(ofType: TestServiceEndpoint.self, toModule: ModuleIdentifier(1)) { actorSystem in
             let serviceEndoint = try TestServiceEndpoint(service, in: actorSystem)
             let clientEndpoint = try TestClientEndpoint.resolve(id: serviceEndoint.id.makeClientEndpoint() , using: actorSystem)
             streamContinuation?.yield(clientEndpoint)

--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -32,34 +32,6 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
     public typealias ResultHandler = RemoteCallResultHandler
     public typealias SerializationRequirement = Transferable
 
-    public struct ModuleIdentifier: Hashable, Codable, CustomStringConvertible {
-        public let rawValue: UInt64
-
-        public var description: String {
-            String(describing: rawValue)
-        }
-
-        public init(_ rawValue: UInt64) {
-            self.rawValue = rawValue
-        }
-
-        public init?(_ rawValue: UInt64?) {
-            if let rawValue {
-                self.rawValue = rawValue
-            } else {
-                return nil
-            }
-        }
-
-        public init?(_ str: String) {
-            if let rawValue = UInt64(str) {
-                self.init(rawValue)
-            } else {
-                return nil
-            }
-        }
-    }
-
     public final class CancellationToken: Hashable {
         private let actorSystem: DistributedSystem
         var serviceName: String?

--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -168,7 +168,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
         self.init(name: systemName, logLevel: logLevel)
     }
 
-    public init(name systemName: String, addressTag: String? = nil, logLevel: Logger.Level = .debug) {
+    public init(name systemName: String, addressTag: String? = nil, logLevel: Logger.Level = .info) {
         self.systemName = systemName
         self.addressTag = addressTag
         eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)

--- a/Sources/DistributedSystem/DistributedSystemErrors.swift
+++ b/Sources/DistributedSystem/DistributedSystemErrors.swift
@@ -10,7 +10,6 @@ import Distributed
 
 public enum DistributedSystemErrors: DistributedActorSystemError {
     case decodeError(description: String)
-    case duplicatedService(String, DistributedSystem.ModuleIdentifier)
     case error(String)
     case noConnectionForActor(EndpointIdentifier)
     case serviceDiscoveryTimeout(String)

--- a/Sources/DistributedSystem/ModuleIdentifier.swift
+++ b/Sources/DistributedSystem/ModuleIdentifier.swift
@@ -1,0 +1,35 @@
+// Copyright 2024 Ordo One AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+public struct ModuleIdentifier: Hashable, Codable, CustomStringConvertible {
+    public let rawValue: UInt64
+
+    public var description: String {
+        String(describing: rawValue)
+    }
+
+    public init(_ rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+
+    public init?(_ rawValue: UInt64?) {
+        if let rawValue {
+            self.rawValue = rawValue
+        } else {
+            return nil
+        }
+    }
+
+    public init?(_ str: String) {
+        if let rawValue = UInt64(str) {
+            self.init(rawValue)
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/ForTesting/TestService/TestService.swift
+++ b/Sources/ForTesting/TestService/TestService.swift
@@ -102,7 +102,7 @@ public class TestService: TestableService, @unchecked Sendable {
         lifecycle.register(label: "System",
                            start: .async {
                                try await self.actorSystem.start(at: NetworkAddress(host: self.serverHost, port: self.serverPort))
-                               let moduleID = DistributedSystem.ModuleIdentifier(1)
+                               let moduleID = ModuleIdentifier(1)
                                try await self.actorSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
                                    let serviceEndpoint = try TestServiceEndpoint(self, in: actorSystem)
                                    self.clientEndpointID = serviceEndpoint.id.makeClientEndpoint()

--- a/Tests/DistributedSystemTests/DistributedSystemTests.swift
+++ b/Tests/DistributedSystemTests/DistributedSystemTests.swift
@@ -164,7 +164,7 @@ final class DistributedSystemTests: XCTestCase {
             let processInfo = ProcessInfo.processInfo
             let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"
 
-            let moduleID = DistributedSystem.ModuleIdentifier(UInt64(processInfo.processIdentifier))
+            let moduleID = ModuleIdentifier(UInt64(processInfo.processIdentifier))
             let actorSystem = DistributedSystemServer(name: systemName)
             try await actorSystem.start()
             try await actorSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
@@ -210,7 +210,7 @@ final class DistributedSystemTests: XCTestCase {
             let processInfo = ProcessInfo.processInfo
             let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"
 
-            let moduleID = DistributedSystem.ModuleIdentifier(1)
+            let moduleID = ModuleIdentifier(1)
             let serverSystem = DistributedSystemServer(name: systemName)
             try await serverSystem.start()
             try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
@@ -321,7 +321,7 @@ final class DistributedSystemTests: XCTestCase {
         let count = 5_000
 
         let service = ServiceImpl(count * 2)
-        let moduleID = DistributedSystem.ModuleIdentifier(UInt64(processInfo.processIdentifier))
+        let moduleID = ModuleIdentifier(UInt64(processInfo.processIdentifier))
         let serverSystem = DistributedSystemServer(name: systemName)
         try await serverSystem.start()
         try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
@@ -460,7 +460,7 @@ final class DistributedSystemTests: XCTestCase {
         let processInfo = ProcessInfo.processInfo
         let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)"
 
-        let moduleID = DistributedSystem.ModuleIdentifier(UInt64(processInfo.processIdentifier))
+        let moduleID = ModuleIdentifier(UInt64(processInfo.processIdentifier))
         let serverSystem = DistributedSystemServer(name: systemName)
         try await serverSystem.start()
         try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
@@ -503,7 +503,7 @@ final class DistributedSystemTests: XCTestCase {
         let processInfo = ProcessInfo.processInfo
         let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"
 
-        let moduleID = DistributedSystem.ModuleIdentifier(UInt64(processInfo.processIdentifier))
+        let moduleID = ModuleIdentifier(UInt64(processInfo.processIdentifier))
         let serverSystem = DistributedSystemServer(name: systemName)
         try await serverSystem.start()
         try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
@@ -552,7 +552,7 @@ final class DistributedSystemTests: XCTestCase {
         let processInfo = ProcessInfo.processInfo
         let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"
 
-        let moduleID = DistributedSystem.ModuleIdentifier(UInt64(processInfo.processIdentifier))
+        let moduleID = ModuleIdentifier(UInt64(processInfo.processIdentifier))
         let serverSystem = DistributedSystemServer(name: systemName)
         try await serverSystem.start()
         try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
@@ -592,7 +592,7 @@ final class DistributedSystemTests: XCTestCase {
         let distributedSystem = DistributedSystemServer(name: systemName)
         try await distributedSystem.start()
 
-        let moduleID = DistributedSystem.ModuleIdentifier(UInt64(processInfo.processIdentifier))
+        let moduleID = ModuleIdentifier(UInt64(processInfo.processIdentifier))
         try await distributedSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
             let service = Service()
             let serviceEndpoint = try TestServiceEndpoint(service, in: actorSystem)
@@ -639,7 +639,7 @@ final class DistributedSystemTests: XCTestCase {
             }
         )
 
-        let moduleID = DistributedSystem.ModuleIdentifier(1)
+        let moduleID = ModuleIdentifier(1)
         try await distributedSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
             let serviceEndpoint = try TestServiceEndpoint(Service(), in: actorSystem)
             return serviceEndpoint
@@ -658,7 +658,7 @@ final class DistributedSystemTests: XCTestCase {
             let serverSystem = DistributedSystemServer(name: systemName)
             try await serverSystem.start()
 
-            let moduleID = DistributedSystem.ModuleIdentifier(1)
+            let moduleID = ModuleIdentifier(1)
             try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
                 let serviceEndpoint = try TestServiceEndpoint(Service(), in: actorSystem)
                 Task { actorSystem.stop() }
@@ -716,7 +716,7 @@ final class DistributedSystemTests: XCTestCase {
         let processInfo = ProcessInfo.processInfo
         let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"
 
-        let moduleID = DistributedSystem.ModuleIdentifier(1)
+        let moduleID = ModuleIdentifier(1)
         let serverSystem = DistributedSystemServer(name: systemName)
         try await serverSystem.start()
         try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
@@ -810,7 +810,7 @@ final class DistributedSystemTests: XCTestCase {
         let stream = AsyncStream<Void>() { continuation = $0 }
         guard let continuation else { fatalError("continuation unexpectedly nil") }
 
-        let moduleID = DistributedSystem.ModuleIdentifier(1)
+        let moduleID = ModuleIdentifier(1)
         let serverSystem = DistributedSystemServer(name: systemName)
         try await serverSystem.start()
         try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
@@ -881,7 +881,7 @@ final class DistributedSystemTests: XCTestCase {
         let stream = AsyncStream<Void>() { continuation = $0 }
         guard let continuation else { fatalError("continuation unexpectedly nil") }
 
-        let moduleID = DistributedSystem.ModuleIdentifier(1)
+        let moduleID = ModuleIdentifier(1)
         let serverSystem = DistributedSystemServer(name: systemName)
 
         // each invocation envelope is about 100 bytes,
@@ -944,7 +944,7 @@ final class DistributedSystemTests: XCTestCase {
 
         let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"
 
-        let moduleID = DistributedSystem.ModuleIdentifier(1)
+        let moduleID = ModuleIdentifier(1)
         let serverSystem = DistributedSystemServer(name: systemName)
 
         serverSystem.healthStatusUpdateInterval = TimeAmount.seconds(90)

--- a/Tests/DistributedSystemTests/GenericDistributedActor.swift
+++ b/Tests/DistributedSystemTests/GenericDistributedActor.swift
@@ -48,7 +48,7 @@ final class GenericDistributedActorTests: XCTestCase {
         let processInfo = ProcessInfo.processInfo
         let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"
 
-        let moduleID = DistributedSystem.ModuleIdentifier(1)
+        let moduleID = ModuleIdentifier(1)
         let serverSystem = DistributedSystemServer(name: systemName)
         try await serverSystem.start()
         try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in

--- a/Tests/DistributedSystemTests/TransferableConformanceTests.swift
+++ b/Tests/DistributedSystemTests/TransferableConformanceTests.swift
@@ -101,7 +101,7 @@ final class TransferableConformanceTests: XCTestCase {
         let stream = AsyncStream<Result<Void, Error>>() { streamContinuation = $0 }
         guard let streamContinuation else { fatalError("Internal error: streamContinuation unexpectedly nil") }
 
-        let moduleID = DistributedSystem.ModuleIdentifier(1)
+        let moduleID = ModuleIdentifier(1)
         let serverSystem = DistributedSystemServer(name: systemName)
         try await serverSystem.start()
         try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
@@ -158,7 +158,7 @@ final class TransferableConformanceTests: XCTestCase {
         let stream = AsyncStream<Result<Void, Error>>() { streamContinuation = $0 }
         guard let streamContinuation else { fatalError("Internal error: streamContinuation unexpectedly nil") }
 
-        let moduleID = DistributedSystem.ModuleIdentifier(1)
+        let moduleID = ModuleIdentifier(1)
         let serverSystem = DistributedSystemServer(name: systemName)
         try await serverSystem.start()
         try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in


### PR DESCRIPTION
## Description

Having it in the module will give a possibility to import only the ModuleIdentifier type instead of the whole DistributedSystem module.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
