### PR TITLE
fix(patch): [sc-8927] Set default log level to info.

### DIFF
--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -192,11 +192,11 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
     @TaskLocal
     private static var actorID: ActorID? // supposed to be private, but need to make it internal for tests
 
-    public convenience init(systemName: String, addressTag: String? = nil, logLevel: Logger.Level = .debug) {
+    public convenience init(systemName: String, addressTag: String? = nil, logLevel: Logger.Level = .info) {
         self.init(name: systemName, addressTag: addressTag, logLevel: logLevel)
     }
 
-    public init(name systemName: String, addressTag: String? = nil, logLevel: Logger.Level = .debug) {
+    public init(name systemName: String, addressTag: String? = nil, logLevel: Logger.Level = .info) {
         self.systemName = systemName
         self.addressTag = addressTag
         eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)


### PR DESCRIPTION
## Description

Set default log level to info.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
