### PR TITLE
fix(patch): [sc-8927] Release local client endpoint when server endpoint resign.

### DIFF
--- a/Sources/DistributedSystem/EndpointIdentifier.swift
+++ b/Sources/DistributedSystem/EndpointIdentifier.swift
@@ -8,7 +8,7 @@
 
 public struct EndpointIdentifier: Hashable, Codable, CustomStringConvertible {
     // keep the side flag in the lower bits for more efficient ULEB128 encoding
-    private static let serviceFlag: UInt32 = 0x00000001
+    static let serviceFlag: UInt32 = 0x00000001
 
     typealias InstanceIdentifier = UInt32
 

--- a/Tests/DistributedSystemTests/DistributedSystemTests.swift
+++ b/Tests/DistributedSystemTests/DistributedSystemTests.swift
@@ -198,7 +198,7 @@ final class DistributedSystemTests: XCTestCase {
         }()
         XCTAssertTrue(flags.serviceDeallocated)
         XCTAssertFalse(flags.serviceConnectionClosed)
-        // XCTAssertTrue(flags.clientDeallocated)
+        XCTAssertTrue(flags.clientDeallocated)
         XCTAssertFalse(flags.clientConnectionClosed)
     }
 


### PR DESCRIPTION
## Description

Release local client endpoint when server endpoint resign.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
