### PR TITLE
fix(patch): [sc-9383] Notify connection state properly for remote client endpoints.

### DIFF
--- a/Sources/DistributedSystem/ChannelHandler.swift
+++ b/Sources/DistributedSystem/ChannelHandler.swift
@@ -62,7 +62,7 @@ class ChannelHandler: ChannelInboundHandler {
         // 2024-03-07T12:48:24.806241+02:00 DEBUG ds : [DistributedSystem] [IPv4]192.168.0.9/192.168.0.9:53019/1: channel inactive ["port": 55056]
         // TODO: it would be nice to know "name/type" of remote process
         logger.info("Channel is inactive, remote: \(context.remoteAddressDescription)/\(id)")
-        actorSystem.channelInactive(context.channel)
+        actorSystem.channelInactive(id, context.channel)
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {

--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -294,16 +294,16 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
             for (actorID, actorInfo) in self.actors {
                 if actorID.channelID == channelID {
                     switch actorInfo {
-                    case let .clientForRemoteService(cfrs):
-                        streamContinuations.append(cfrs.continuation)
-                    case let .serviceForRemoteClient(sfrc):
-                        streamContinuations.append(sfrc.continuation)
-                    case let .remoteClient(rcs), let .remoteService(rcs):
+                    case let .clientForRemoteService(inbound),
+                         let .serviceForRemoteClient(inbound):
+                        streamContinuations.append(inbound.continuation)
+                    case let .remoteClient(outbound),
+                         let .remoteService(outbound):
                         actors.append(actorID)
-                        if rcs.suspended {
-                            endpointContinuations.append(contentsOf: rcs.continuations)
+                        if outbound.suspended {
+                            endpointContinuations.append(contentsOf: outbound.continuations)
                         } else {
-                            assert(rcs.continuations.isEmpty)
+                            assert(outbound.continuations.isEmpty)
                         }
                     default:
                         break
@@ -683,10 +683,9 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
         for (actorID, actorInfo) in self.actors {
             if actorID.channelID == channelID {
                 switch actorInfo {
-                case let .clientForRemoteService(cfrs):
-                    actors.append((actorID, cfrs.continuation, cfrs.queueState))
-                case let .serviceForRemoteClient(sfrc):
-                    actors.append((actorID, sfrc.continuation, sfrc.queueState))
+                case let .clientForRemoteService(inbound),
+                     let .serviceForRemoteClient(inbound):
+                    actors.append((actorID, inbound.continuation, inbound.queueState))
                 default:
                     break
                 }


### PR DESCRIPTION
## Description

Notify connection state properly for remote client endpoints.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [X] I have added unit and/or integration tests that prove my fix is effective or that my feature works
