### PR TITLE
fix(patch): [sc-10502] Encode remote target names as integer.

### DIFF
--- a/Sources/DistributedSystem/ChannelHandler.swift
+++ b/Sources/DistributedSystem/ChannelHandler.swift
@@ -38,6 +38,7 @@ class ChannelHandler: ChannelInboundHandler {
     private let actorSystem: DistributedSystem
     private var address: SocketAddress?
     private var writeBufferHighWatermark: Int
+    private var targetFuncs = [String]()
 
     init(_ id: UInt32, _ actorSystem: DistributedSystem, _ address: SocketAddress?, _ writeBufferHighWatermark: UInt64) {
         self.id = id
@@ -74,7 +75,7 @@ class ChannelHandler: ChannelInboundHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         var buffer = unwrapInboundIn(data)
         logger.trace("\(context.channel.addressDescription)/\(id): received \(buffer.readableBytes) bytes")
-        actorSystem.channelRead(id, context.channel, &buffer)
+        actorSystem.channelRead(id, context.channel, &buffer, &targetFuncs)
     }
 
     // Flush it out. This can make use of gathering writes if multiple buffers are pending

--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -107,7 +107,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
     static let pingInterval = TimeAmount.seconds(2)
     static let serviceDiscoveryTimeout = TimeAmount.seconds(5)
 
-    static let protocolVersionMajor: UInt16 = 1
+    static let protocolVersionMajor: UInt16 = 2
     static let protocolVersionMinor: UInt16 = 0
 
     enum SessionMessage: UInt16 {


### PR DESCRIPTION
## Description

Encode remote target names as integer to reduce e amount of transmitted data.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
