### PR TITLE
fix(patch): [sc-6337] Use lz4 provided by package-system-libs instead of own declared.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let externalDependencies: [String: Range<Version>] = [
     "https://github.com/apple/swift-log": .upToNextMajor(from: "1.4.4"),
     "https://github.com/ordo-one/swift-service-lifecycle_1.0": .upToNextMajor(from: "1.0.0-alpha.13"), // to remove in future
     "https://github.com/apple/swift-service-discovery.git" : .upToNextMajor(from: "1.0.0"),
+    "https://github.com/ordo-one/package-system-libs": .upToNextMajor(from: "0.0.1"),
 ]
 
 let internalDependencies: [String: Range<Version>] = [
@@ -77,14 +78,14 @@ let package = Package(
         .target(
             name: "DistributedSystem",
             dependencies: [
-                "lz4",
-                .product(name: "PackageConcurrencyHelpers", package: "package-concurrency-helpers"),
                 .product(name: "ConsulServiceDiscovery", package: "package-consul"),
+                .product(name: "Helpers", package: "package-concurrency-helpers"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "lz4", package: "package-system-libs"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
-                .product(name: "Logging", package: "swift-log"),
+                .product(name: "PackageConcurrencyHelpers", package: "package-concurrency-helpers"),
                 .product(name: "ServiceDiscovery", package: "swift-service-discovery"),
-                .product(name: "Helpers", package: "package-concurrency-helpers"),
             ],
             swiftSettings:[
                 .enableExperimentalFeature("AccessLevelOnImport")
@@ -148,11 +149,6 @@ let package = Package(
                 "DistributedSystem",
                 "TestMessages",
             ]
-        ),
-        .systemLibrary(
-            name: "lz4",
-            pkgConfig: "liblz4",
-            providers: [.apt(["liblz4-dev"]), .brew(["lz4"])]
         ),
     ]
 )

--- a/Sources/lz4/lz4shims.h
+++ b/Sources/lz4/lz4shims.h
@@ -1,1 +1,0 @@
-#include <lz4.h>

--- a/Sources/lz4/module.modulemap
+++ b/Sources/lz4/module.modulemap
@@ -1,5 +1,0 @@
-module lz4 [system] {
-    umbrella header "lz4shims.h"
-    link "lz4"
-    export *
-}


### PR DESCRIPTION
## Description

Use lz4 provided by package-system-libs instead of own declared system library to avoid conflicts.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
