### PR TITLE
fix(patch): [sc-6337] Set outbound queue watermark at channel initialization point instead of the last handler activation point.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Distributed system can compress traffic using LZ4 library. There are 3 compressi
 - disabled
 - streaming compression, using LZ4 double buffer
 - dictionary compression
+
 The compression mode set for a distributed system instance defines the compression for outbound data. Therefore, when two distributed system instances with different compression modes connect, each data direction will use a different compression mode.
 
 ## Work is in progress!

--- a/Sources/DistributedSystem/ChannelCompression.swift
+++ b/Sources/DistributedSystem/ChannelCompression.swift
@@ -359,6 +359,11 @@ final class ChannelCompressionHandshakeClient: ChannelInboundHandler, RemovableC
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        if let timer {
+            timer.cancel()
+            self.timer = nil
+        }
+
         var buffer = unwrapInboundIn(data)
         guard let handshakeResponseRaw = buffer.readInteger(as: HandshakeResponse.RawValue.self) else {
             logger.info("\(context.channel.addressDescription): invalid compression response received, close connection")

--- a/Sources/DistributedSystem/ChannelHandler.swift
+++ b/Sources/DistributedSystem/ChannelHandler.swift
@@ -50,12 +50,8 @@ class ChannelHandler: ChannelInboundHandler {
     func channelActive(context: ChannelHandlerContext) {
         // 2024-03-07T12:51:20.589375+02:00 DEBUG ds : [DistributedSystem] [IPv4]192.168.0.9/192.168.0.9:58186/3: channel active ["port": 55056]
         // TODO: it would be nice to know "name/type" of remote process
-        logger.debug("\(context.channel.addressDescription): channel active")
-
         let channel = context.channel
-
-        let writeBufferWaterMark = ChannelOptions.Types.WriteBufferWaterMark(low: writeBufferHighWatermark/2, high: writeBufferHighWatermark)
-        _ = channel.setOption(ChannelOptions.writeBufferWaterMark, value: writeBufferWaterMark)
+        logger.debug("\(channel.addressDescription): channel active")
 
         actorSystem.setChannel(id, channel, forProcessAt: address)
         if address == nil {

--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -285,6 +285,10 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
             .channelOption(ChannelOptions.tcpOption(.tcp_nodelay), value: 1)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .channelInitializer { channel in
+                let writeBufferWaterMark = ChannelOptions.Types.WriteBufferWaterMark(
+                    low: Int(self.endpointQueueWarningSize/2),
+                    high: Int(self.endpointQueueWarningSize))
+                _ = channel.setOption(ChannelOptions.writeBufferWaterMark, value: writeBufferWaterMark)
                 let pipeline = channel.pipeline
                 let channelHandler = ChannelHandler(self.nextChannelID, self, address, self.endpointQueueWarningSize)
                 return pipeline.addHandler(ChannelCounters(self), name: ChannelCounters.name).flatMap { _ in

--- a/Sources/DistributedSystem/DistributedSystemServer.swift
+++ b/Sources/DistributedSystem/DistributedSystemServer.swift
@@ -33,6 +33,10 @@ public class DistributedSystemServer: DistributedSystem {
             .serverChannelOption(ChannelOptions.tcpOption(.tcp_nodelay), value: 1)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
+                let writeBufferWaterMark = ChannelOptions.Types.WriteBufferWaterMark(
+                    low: Int(self.endpointQueueWarningSize/2),
+                    high: Int(self.endpointQueueWarningSize))
+                _ = channel.setOption(ChannelOptions.writeBufferWaterMark, value: writeBufferWaterMark)
                 let pipeline = channel.pipeline
                 let channelHandler = ChannelHandler(self.nextChannelID, self, nil, self.endpointQueueWarningSize)
                 return pipeline.addHandler(ChannelCounters(self), name: ChannelCounters.name).flatMap { _ in


### PR DESCRIPTION
## Description

Set outbound queue watermark at channel initialization point instead of the last handler activation point.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
