### PR TITLE
fix(patch): [sc-10387] Try to reconnect to service while it is in Consul.

### DIFF
--- a/Sources/DistributedSystem/ChannelHandler.swift
+++ b/Sources/DistributedSystem/ChannelHandler.swift
@@ -36,7 +36,7 @@ class ChannelHandler: ChannelInboundHandler {
 
     private let id: UInt32
     private let actorSystem: DistributedSystem
-    private var address: SocketAddress?
+    private let address: SocketAddress?
     private var writeBufferHighWatermark: Int
     private var targetFuncs = [String]()
 

--- a/Sources/DistributedSystem/ChannelHandler.swift
+++ b/Sources/DistributedSystem/ChannelHandler.swift
@@ -54,18 +54,13 @@ class ChannelHandler: ChannelInboundHandler {
         logger.debug("\(channel.addressDescription): channel active")
 
         actorSystem.setChannel(id, channel, forProcessAt: address)
-        if address == nil {
-            // address is empty for the server side,
-            // and can be changed after actorSysten.setChannel() call
-            address = context.remoteAddress
-        }
     }
 
     func channelInactive(context: ChannelHandlerContext) {
         // 2024-03-07T12:48:24.806241+02:00 DEBUG ds : [DistributedSystem] [IPv4]192.168.0.9/192.168.0.9:53019/1: channel inactive ["port": 55056]
         // TODO: it would be nice to know "name/type" of remote process
         logger.info("\(context.channel.addressDescription): connection closed (ChannelHandler)")
-        actorSystem.channelInactive(id, context.channel)
+        actorSystem.channelInactive(id, address)
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {

--- a/Tests/DistributedSystemTests/DistributedSystemTests.swift
+++ b/Tests/DistributedSystemTests/DistributedSystemTests.swift
@@ -294,6 +294,67 @@ final class DistributedSystemTests: XCTestCase {
     }
     */
 
+    func testReconnect() async throws {
+        // Checking the distributed actors do not leak,
+        // use a closure here to be sure at the check point all references will be released
+        let flags = Flags()
+        _ = try await {
+            let processInfo = ProcessInfo.processInfo
+            let systemName = "\(processInfo.hostName)-ts-\(processInfo.processIdentifier)-\(#line)"
+
+            let moduleID = DistributedSystem.ModuleIdentifier(1)
+            let serverSystem = DistributedSystemServer(name: systemName)
+            try await serverSystem.start()
+            try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
+                let service = ServiceWithLeakCheckImpl(flags)
+                let serviceEndpoint = try TestServiceEndpoint(service, in: actorSystem)
+                let clientEndpointID = serviceEndpoint.id.makeClientEndpoint()
+                service.clientEndpoint = try TestClientEndpoint.resolve(id: clientEndpointID, using: actorSystem)
+                return serviceEndpoint
+            }
+
+            let clientSystem = DistributedSystem(name: systemName)
+            try clientSystem.start()
+
+            let clientIdAtomic = ManagedAtomic<Int>(0)
+            var client: ClientWithLeakCheckImpl? = ClientWithLeakCheckImpl(flags)
+
+            clientSystem.connectToServices(
+                TestServiceEndpoint.self,
+                withFilter: { _ in true },
+                clientFactory: { actorSystem, _ in TestClientEndpoint(client!, in: actorSystem) },
+                serviceHandler: { serviceEndpoint, _ in
+                    Task {
+                        do {
+                            let clientId = clientIdAtomic.wrappingIncrementThenLoad(ordering: .relaxed)
+                            if clientId == 1 {
+                                try serverSystem.closeConnectionFor(serviceEndpoint.id)
+                            } else if clientId == 2 {
+                                let openRequest = _OpenRequestStruct(requestIdentifier: 1)
+                                try await serviceEndpoint.openStream(byRequest: OpenRequest(openRequest))
+                            } else {
+                                fatalError("internal error")
+                            }
+                        } catch {
+                            logger.error("\(error)")
+                        }
+                    }
+                }
+            )
+
+            for await _ in client!.stream { break }
+            client = nil
+
+            clientSystem.stop()
+            serverSystem.stop()
+        }()
+
+        XCTAssertTrue(flags.serviceDeallocated)
+        XCTAssertTrue(flags.serviceConnectionClosed)
+        XCTAssertTrue(flags.clientDeallocated)
+        XCTAssertTrue(flags.clientConnectionClosed)
+    }
+
     func testConcurrentRemoteCalls() async throws {
         class ServiceImpl: TestableService {
             private let totalCount: Int


### PR DESCRIPTION
## Description

Sometimes connection between processes breaks while processes still operates properly.
DS will try to reconnect while service is in the Consul with reconnect interval 5 seconds.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
