### PR TITLE
fix(patch): [sc-6337] Update compression stats in DS on channel inactivation.

### DIFF
--- a/Sources/DistributedSystem/ChannelCompression.swift
+++ b/Sources/DistributedSystem/ChannelCompression.swift
@@ -518,12 +518,13 @@ class ChannelCompressionInboundHandler: ChannelInboundHandler {
         self.distributedSystem = distributedSystem
     }
 
-    deinit {
-        distributedSystem.incrementStats([Self.statsKey: bytesDecompressed])
-    }
-
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         fatalError("should never be called")
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        context.fireChannelInactive()
+        distributedSystem.incrementStats([Self.statsKey: bytesDecompressed])
     }
 }
 
@@ -609,7 +610,9 @@ final class ChannelDictCompressionInboundHandler: ChannelCompressionInboundHandl
     }
 }
 
-class ChannelCompressionOutboundHandler: ChannelOutboundHandler {
+class ChannelCompressionOutboundHandler: ChannelInboundHandler, ChannelOutboundHandler {
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = ByteBuffer
     typealias OutboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
 
@@ -623,7 +626,8 @@ class ChannelCompressionOutboundHandler: ChannelOutboundHandler {
         self.distributedSystem = distributedSystem
     }
 
-    deinit {
+    func channelInactive(context: ChannelHandlerContext) {
+        context.fireChannelInactive()
         distributedSystem.incrementStats([Self.statsKey: bytesCompressed])
     }
 

--- a/Sources/DistributedSystem/ChannelCounters.swift
+++ b/Sources/DistributedSystem/ChannelCounters.swift
@@ -33,14 +33,15 @@ final class ChannelCounters: ChannelInboundHandler, ChannelOutboundHandler {
         self.distributedSystem = distributedSystem
     }
 
-    deinit {
-        distributedSystem.incrementStats(stats)
-    }
-
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let buffer = unwrapInboundIn(data)
         bytesReceived.wrappingIncrement(by: UInt64(buffer.readableBytes), ordering: .relaxed)
         context.fireChannelRead(data)
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        context.fireChannelInactive()
+        distributedSystem.incrementStats(stats)
     }
 
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {

--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -846,7 +846,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
                 strs.append(", bytes_received=\(bytesReceived)")
                 if let bytesDecompressed = stats[ChannelCompressionInboundHandler.statsKey] {
                     strs.append(", bytes_decompressed=\(bytesDecompressed), ")
-                    strs.append("inbound compression ratio=\(Self.calculateSpaceSaving(dataSize: bytesDecompressed, compressedSize: bytesReceived))%")
+                    strs.append("inbound space saving=\(Self.calculateSpaceSaving(dataSize: bytesDecompressed, compressedSize: bytesReceived))%")
                 }
             }
             return strs.joined()


### PR DESCRIPTION
## Description

Seems like deinitialization does not work well for statistic update,
let's try to update compression stats on channel inactivation instead.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
