### PR TITLE
fix(patch): [sc-11234] Avoid connection to process if service filter returned false.

### DIFF
--- a/Sources/DistributedSystem/DiscoveryManager.swift
+++ b/Sources/DistributedSystem/DiscoveryManager.swift
@@ -259,19 +259,20 @@ final class DiscoveryManager {
                         return (false, nil)
                     }
                 } else {
-                    var pendingHandlers = [DistributedSystem.ConnectionHandler]()
+                    var pendingServices = [(NodeService, DistributedSystem.ConnectionHandler)]()
                     for filterInfo in discoveryInfo.filters.values {
                         if filterInfo.filter(service) {
-                            pendingHandlers.append(filterInfo.connectionHandler)
+                            pendingServices.append((service, filterInfo.connectionHandler))
                         }
                     }
-                    if pendingHandlers.isEmpty {
+                    if pendingServices.isEmpty {
                         return (false, nil)
+                    } else {
+                        let processInfo = ProcessInfo()
+                        processInfo.pendingServices = pendingServices
+                        self.processes[address] = processInfo
+                        return (true, nil)
                     }
-                    let processInfo = ProcessInfo()
-                    processInfo.pendingServices = pendingHandlers.map { (service, $0) }
-                    self.processes[address] = processInfo
-                    return (true, nil)
                 }
             }
         }

--- a/Sources/DistributedSystem/DiscoveryManager.swift
+++ b/Sources/DistributedSystem/DiscoveryManager.swift
@@ -1,4 +1,4 @@
-// Copyright 2023 Ordo One AB
+// Copyright 2024 Ordo One AB
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Avoid connection to process if service filter returned false.

## How Has This Been Tested?

Manual tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
