### PR TITLE
fix(patch): [sc-6593] Remove dependency on package-latency-tools.

### DIFF
--- a/Benchmarks/DistributedSystem/ServerAndClient.swift
+++ b/Benchmarks/DistributedSystem/ServerAndClient.swift
@@ -1,6 +1,5 @@
 import Benchmark
 import DistributedSystem
-import LatencyStatistics
 import LatencyTimer
 import Logging
 import PackageConcurrencyHelpers
@@ -10,8 +9,6 @@ public class Client: TestableClient {
     private let logger: Logger
 
     let lock = Lock()
-
-    var statistics = LatencyStatistics()
 
     var snapshotDoneReceived = false
     var snapshotDoneContinuation: CheckedContinuation<Void, Never>?

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,6 @@ let internalDependencies: [String: Range<Version>] = [
     "package-benchmark": .upToNextMajor(from: "1.0.0"),
     "package-concurrency-helpers": .upToNextMajor(from: "4.0.0"),
     "package-consul": .upToNextMajor(from: "6.0.0"),
-    "package-latency-tools": .upToNextMajor(from: "1.0.0"),
 ]
 
 func makeDependencies() -> [Package.Dependency] {
@@ -134,7 +133,6 @@ let package = Package(
                 .product(name: "PackageConcurrencyHelpers", package: "package-concurrency-helpers"),
                 .product(name: "Benchmark", package: "package-benchmark"),
                 .product(name: "BenchmarkPlugin", package: "package-benchmark"),
-                .product(name: "LatencyStatistics", package: "package-latency-tools"),
             ],
             path: "Benchmarks/DistributedSystem",
             swiftSettings: [


### PR DESCRIPTION
## Description

Remove dependency on package-latency-tools.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
