### PR TITLE
fix(patch): [sc-16656] Handle properly a case when first service registration failed.

### DIFF
--- a/Sources/DistributedSystem/DiscoveryManager.swift
+++ b/Sources/DistributedSystem/DiscoveryManager.swift
@@ -81,16 +81,6 @@ final class DiscoveryManager {
         var discover = true
         var filters: [DistributedSystem.CancellationToken: FilterInfo] = [:]
         var services: [UUID: ServiceInfo] = [:]
-
-        var addedServices: Int {
-            services.reduce(0, {
-                if case .local = $1.value.address {
-                    return $0 + 1
-                } else {
-                    return $0
-                }
-            })
-        }
     }
 
     private var loggerBox: Box<Logger>
@@ -99,6 +89,7 @@ final class DiscoveryManager {
     private var lock = NIOLock()
     private var processes: [SocketAddress: ProcessInfo] = [:]
     private var discoveries: [String: DiscoveryInfo] = [:]
+    private var addedServices = 0
     private var stopped = false
 
     init(_ loggerBox: Box<Logger>) {
@@ -225,8 +216,8 @@ final class DiscoveryManager {
         _ factory: @escaping DistributedSystem.ServiceFactory
     ) -> Bool {
         let (updateHealthStatus, services) = lock.withLock {
-            let addedServices = discoveries.reduce(0, { $0 + $1.value.addedServices })
-            let updateHealthStatus = (addedServices == 0)
+            let updateHealthStatus = (self.addedServices == 0) ? true : false
+            self.addedServices += 1
 
             var discoveryInfo = self.discoveries[serviceName]
             if discoveryInfo == nil {

--- a/Sources/DistributedSystem/DiscoveryManager.swift
+++ b/Sources/DistributedSystem/DiscoveryManager.swift
@@ -89,7 +89,7 @@ final class DiscoveryManager {
     private var lock = NIOLock()
     private var processes: [SocketAddress: ProcessInfo] = [:]
     private var discoveries: [String: DiscoveryInfo] = [:]
-    private var addedServices = 0
+    private var updateHealthStatus = true
     private var stopped = false
 
     init(_ loggerBox: Box<Logger>) {
@@ -216,8 +216,8 @@ final class DiscoveryManager {
         _ factory: @escaping DistributedSystem.ServiceFactory
     ) -> Bool {
         let (updateHealthStatus, services) = lock.withLock {
-            let updateHealthStatus = (self.addedServices == 0) ? true : false
-            self.addedServices += 1
+            let updateHealthStatus = self.updateHealthStatus
+            self.updateHealthStatus = false
 
             var discoveryInfo = self.discoveries[serviceName]
             if discoveryInfo == nil {

--- a/Sources/DistributedSystem/DistributedSystemServer.swift
+++ b/Sources/DistributedSystem/DistributedSystemServer.swift
@@ -140,16 +140,10 @@ public class DistributedSystemServer: DistributedSystem {
 
         let (serviceID, updateHealthStatus) = super.addService(name, metadata, factory)
         let future = registerService(name, serviceID, metadata: metadata)
-        var registrationError: Error?
-        do {
-            try await future.get()
-        } catch {
-            registrationError = error
-        }
 
         // if super.addService() requested health status update
         // it is still better to schedule it even if service registration failed,
-        // because super.addService() will never request health status update again.
+        // because super.addService() will never request health status update again
 
         if updateHealthStatus {
             let eventLoop = eventLoopGroup.next()
@@ -158,8 +152,6 @@ public class DistributedSystemServer: DistributedSystem {
             }
         }
 
-        if let registrationError {
-            throw registrationError
-        }
+        try await future.get()
     }
 }


### PR DESCRIPTION
## Description

Handle properly a case when first service registration failed.

## How Has This Been Tested?

In the case if first service registration failed and health status update requested,
then health status update was not actually scheduled and services soon would be
deregistered in the `Consul`.

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
