### PR TITLE
fix(patch): [sc-16715] Log an error instead of fatalError() in case if DiscoveryManager.setAddress() called for unknown service.

### DIFF
--- a/Sources/DistributedSystem/DiscoveryManager.swift
+++ b/Sources/DistributedSystem/DiscoveryManager.swift
@@ -254,7 +254,8 @@ final class DiscoveryManager {
     func setAddress(_ address: SocketAddress, for serviceName: String, _ serviceID: UUID, _ service: NodeService) -> Bool {
         let (connect, process) = lock.withLock { () -> (Bool, (channel: (UInt32, Channel), connectionHandlers: [DistributedSystem.ConnectionHandler])?) in
             guard let discoveryInfo = self.discoveries[serviceName] else {
-                fatalError("Internal error: service \(serviceName) not discovered")
+                logger.error("internal error: service \(serviceName)/\(serviceID) not discovered")
+                return (false, nil)
             }
             if let serviceInfo = discoveryInfo.services[serviceID] {
                 if case let .remote(serviceAddress) = serviceInfo.address {


### PR DESCRIPTION
## Description

 Log an error instead of fatalError() in case if DiscoveryManager.setAddress() called for unknown service.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
