### PR TITLE
fix(patch): [sc-16715] Reconnect properly in a case if service removed from the Consul and then appears again.

### DIFF
--- a/Sources/DistributedSystem/DiscoveryManager.swift
+++ b/Sources/DistributedSystem/DiscoveryManager.swift
@@ -308,13 +308,13 @@ final class DiscoveryManager {
 
     func removeService(_ serviceName: String, _ serviceID: UUID) {
         lock.withLockVoid {
-            logger.trace("remove service \(serviceName)/\(serviceID)")
+            logger.debug("remove service \(serviceName)/\(serviceID)")
             guard let discoveryInfo = self.discoveries[serviceName] else {
                 logger.error("internal error: no services \(serviceName) registered")
                 return
             }
             if discoveryInfo.services.removeValue(forKey: serviceID) != nil {
-                if discoveryInfo.services.isEmpty {
+                if discoveryInfo.services.isEmpty && discoveryInfo.filters.isEmpty {
                     self.discoveries.removeValue(forKey: serviceName)
                 }
             }

--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -105,7 +105,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
     public typealias ResultHandler = RemoteCallResultHandler
     public typealias SerializationRequirement = Transferable
 
-    public struct ModuleIdentifier: Hashable, Codable, CustomStringConvertible {
+    public struct ModuleIdentifier: Hashable, Codable, CustomStringConvertible, Sendable {
         public let rawValue: UInt64
 
         public var description: String {


### PR DESCRIPTION
## Description

Reconnect properly in a case if service removed from the Consul and then appears again.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
