### PR TITLE
fix(patch): [sc-16715] Log an error instead of fatalError() in a case if can't find channel for distributed actor.

### DIFF
--- a/Benchmarks/DistributedSystem/DistributedSystemBenchmarks.swift
+++ b/Benchmarks/DistributedSystem/DistributedSystemBenchmarks.swift
@@ -67,9 +67,10 @@ let benchmarks = {
         let (stream, streamContinuation) = AsyncStream.makeStream(of: TestClientEndpoint.self)
         var streamIterator = stream.makeAsyncIterator()
 
-        try await serviceSystem.addService(ofType: TestServiceEndpoint.self, toModule: DistributedSystem.ModuleIdentifier(1)) { actorSystem in
+        let moduleId = DistributedSystem.ModuleIdentifier(1)
+        try await serviceSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleId) { actorSystem in
             let serviceEndoint = try TestServiceEndpoint(service, in: actorSystem)
-            let clientEndpoint = try TestClientEndpoint.resolve(id: serviceEndoint.id.makeClientEndpoint() , using: actorSystem)
+            let clientEndpoint = try TestClientEndpoint.resolve(id: serviceEndoint.id.makeClientEndpoint(), using: actorSystem)
             streamContinuation.yield(clientEndpoint)
             return serviceEndoint
         }

--- a/Benchmarks/DistributedSystem/ServerAndClient.swift
+++ b/Benchmarks/DistributedSystem/ServerAndClient.swift
@@ -27,7 +27,7 @@ public class Client: TestableClient {
                     blackHole(idx)
                 }
             }
-            let elapsedMicroseconds = Int(elapsed.nanoseconds() / 1000)
+            let elapsedMicroseconds = Int(elapsed.nanoseconds() / 1_000)
             receiveSleepIterations = calibrateIterations / elapsedMicroseconds * 1_000_000 / newValue
         }
     }

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ The basic element of the system is a module that combines several different serv
 ## Register service
 In order to register a service in the distributed system the function `addService` supposed to be used:
 ```
-   func addService(_ serviceName: String,
-                    _ metadata: [String: String],
-                    _ factory: @escaping ServiceFactory) -> ServiceIdentifier
+   func addService(
+       _ serviceName: String,
+       _ metadata: [String: String],
+       _ factory: @escaping ServiceFactory
+   ) -> ServiceIdentifier
 ```
 where
 - `serviceName`: name of the service

--- a/Sources/DistributedSystem/ChannelHandler.swift
+++ b/Sources/DistributedSystem/ChannelHandler.swift
@@ -53,7 +53,6 @@ class ChannelHandler: ChannelInboundHandler {
         // TODO: it would be nice to know "name/type" of remote process
         let channel = context.channel
         logger.debug("\(channel.addressDescription)/\(Self.self): channel active")
-
         actorSystem.setChannel(id, channel, forProcessAt: address)
     }
 

--- a/Sources/DistributedSystem/DistributedSystemErrors.swift
+++ b/Sources/DistributedSystem/DistributedSystemErrors.swift
@@ -12,7 +12,6 @@ public enum DistributedSystemErrors: DistributedActorSystemError {
     case decodeError(description: String)
     case duplicatedService(String, DistributedSystem.ModuleIdentifier)
     case error(String)
-    case noConnectionForActor(EndpointIdentifier)
     case serviceDiscoveryTimeout(String)
     case unexpectedResultType(String)
     case connectionLost


### PR DESCRIPTION
## Description

Log an error instead of fatalError() in a case if can't find channel for distributed actor.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
