### PR TITLE
fix(major): [sc-13510] Use Data instead of UnsafeRawPointer to share dictionary to be Swift6 compliant.

### DIFF
--- a/Sources/DistributedSystem/ChannelCompression.swift
+++ b/Sources/DistributedSystem/ChannelCompression.swift
@@ -25,6 +25,7 @@ private enum HandshakeResponse: UInt8 {
 }
 
 extension ChannelHandlerContext: @unchecked @retroactive Sendable {}
+extension ByteToMessageHandler: @unchecked @retroactive Sendable {}
 
 final class ChannelCompressionHandshakeServer: ChannelInboundHandler, RemovableChannelHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
@@ -184,7 +185,7 @@ final class ChannelCompressionHandshakeServer: ChannelInboundHandler, RemovableC
             return
         }
 
-        future.flatMap {
+        future.flatMap { [buffer] in
             _ = pipeline.removeHandler(self)
             prevContext.fireChannelActive()
             if buffer.readableBytes > 0 {

--- a/Sources/DistributedSystem/ChannelCounters.swift
+++ b/Sources/DistributedSystem/ChannelCounters.swift
@@ -9,7 +9,7 @@
 import Atomics
 import NIOCore
 
-final class ChannelCounters: ChannelInboundHandler, ChannelOutboundHandler {
+final class ChannelCounters: ChannelInboundHandler, ChannelOutboundHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
     typealias OutboundIn = ByteBuffer

--- a/Sources/DistributedSystem/ChannelHandshake.swift
+++ b/Sources/DistributedSystem/ChannelHandshake.swift
@@ -9,7 +9,7 @@
 import Logging
 import NIOCore
 
-final class ChannelHandshakeServer: ChannelInboundHandler, RemovableChannelHandler {
+final class ChannelHandshakeServer: ChannelInboundHandler, RemovableChannelHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
 
     private let distributedSystem: DistributedSystem
@@ -97,7 +97,7 @@ final class ChannelHandshakeServer: ChannelInboundHandler, RemovableChannelHandl
     }
 }
 
-final class ChannelHandshakeClient: ChannelInboundHandler, RemovableChannelHandler {
+final class ChannelHandshakeClient: ChannelInboundHandler, RemovableChannelHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
 
     private let distributedSystem: DistributedSystem

--- a/Sources/DistributedSystem/SyncCallManager.swift
+++ b/Sources/DistributedSystem/SyncCallManager.swift
@@ -35,7 +35,10 @@ class SyncCallManager {
         self.loggerBox = loggerBox
     }
 
-    private func resumeContinuation(_ continuation: CheckedContinuation<any DistributedSystem.SerializationRequirement, Error>, with result: inout ByteBuffer) {
+    private func resumeContinuation(
+        _ continuation: CheckedContinuation<any DistributedSystem.SerializationRequirement, Error>,
+        with result: inout ByteBuffer
+    ) {
         guard let typeHintSize = result.readInteger(as: UInt16.self),
               let typeHint = result.readString(length: Int(typeHintSize)) else {
             continuation.resume(throwing: DistributedSystemErrors.error("Invalid result received"))

--- a/Tests/DistributedSystemTests/DistributedSystemTests.swift
+++ b/Tests/DistributedSystemTests/DistributedSystemTests.swift
@@ -241,7 +241,7 @@ final class DistributedSystemTests: XCTestCase {
 
             let moduleID = DistributedSystem.ModuleIdentifier(1)
             let serverDictionary = try loadResource("dict4Kb-mix")
-            let serverCompressionMode: CompressionMode = .dictionary(.init(serverDictionary))
+            let serverCompressionMode: CompressionMode = .dictionary(serverDictionary)
             let serverSystem = DistributedSystemServer(name: systemName, compressionMode: serverCompressionMode)
             try await serverSystem.start()
             try await serverSystem.addService(ofType: TestServiceEndpoint.self, toModule: moduleID) { actorSystem in
@@ -253,7 +253,7 @@ final class DistributedSystemTests: XCTestCase {
             }
 
             let clientDictionary = try loadResource("dict4Kb-pt")
-            let clientCompressionMode: CompressionMode = .dictionary(.init(clientDictionary))
+            let clientCompressionMode: CompressionMode = .dictionary(clientDictionary)
             let clientSystem = DistributedSystem(name: systemName, compressionMode: clientCompressionMode)
             try clientSystem.start()
 


### PR DESCRIPTION
## Description

Include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
