### PR TITLE
fix(patch): [sc-21938] Use Synchronization.Atomic instead of Atomics.ManagedAtomic where it is possible.

### DIFF
--- a/Sources/DistributedSystem/ChannelCounters.swift
+++ b/Sources/DistributedSystem/ChannelCounters.swift
@@ -6,8 +6,8 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 
-import Atomics
 import NIOCore
+import Synchronization
 
 final class ChannelCounters: ChannelInboundHandler, ChannelOutboundHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
@@ -15,9 +15,9 @@ final class ChannelCounters: ChannelInboundHandler, ChannelOutboundHandler, @unc
     typealias OutboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
 
-    private var distributedSystem: DistributedSystem
-    private var bytesReceived = ManagedAtomic<UInt64>(0)
-    private var bytesSent = ManagedAtomic<UInt64>(0)
+    private let distributedSystem: DistributedSystem
+    private let bytesReceived = Atomic<UInt64>(0)
+    private let bytesSent = Atomic<UInt64>(0)
 
     static let name = "channelCounters"
     static let keyBytesReceived = "bytes_received"
@@ -35,7 +35,7 @@ final class ChannelCounters: ChannelInboundHandler, ChannelOutboundHandler, @unc
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let buffer = unwrapInboundIn(data)
-        bytesReceived.wrappingIncrement(by: UInt64(buffer.readableBytes), ordering: .relaxed)
+        bytesReceived.wrappingAdd(UInt64(buffer.readableBytes), ordering: .relaxed)
         context.fireChannelRead(data)
     }
 
@@ -46,7 +46,7 @@ final class ChannelCounters: ChannelInboundHandler, ChannelOutboundHandler, @unc
 
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let buffer = unwrapOutboundIn(data)
-        bytesSent.wrappingIncrement(by: UInt64(buffer.readableBytes), ordering: .relaxed)
+        bytesSent.wrappingAdd(UInt64(buffer.readableBytes), ordering: .relaxed)
         context.write(wrapOutboundOut(buffer), promise: promise)
     }
 }

--- a/Sources/DistributedSystem/DistributedSystem.swift
+++ b/Sources/DistributedSystem/DistributedSystem.swift
@@ -16,6 +16,7 @@ import Logging
 import struct Foundation.Data
 import struct Foundation.UUID
 import NIOCore
+import Synchronization
 internal import NIOPosix
 internal import struct NIOConcurrencyHelpers.NIOLock
 internal import struct NIOConcurrencyHelpers.NIOLockedValueBox
@@ -243,13 +244,13 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
     private var channels: [UInt32: ChannelInfo] = [:]
     private var stats: [String: UInt64] = [:]
 
-    private let _nextChannelID = ManagedAtomic<UInt32>(1) // 0 reserved for local endpoints
-    var nextChannelID: UInt32 { _nextChannelID.loadThenWrappingIncrement(ordering: .relaxed) }
+    private let _nextChannelID = Atomic<UInt32>(1) // 0 reserved for local endpoints
+    var nextChannelID: UInt32 { _nextChannelID.add(1, ordering: .relaxed).oldValue }
 
-    private let _nextInstanceID = ManagedAtomic<UInt32>(1)
-    private var nextInstanceID: UInt32 { _nextInstanceID.loadThenWrappingIncrement(ordering: .relaxed) }
+    private let _nextInstanceID = Atomic<UInt32>(1)
+    private var nextInstanceID: UInt32 { _nextInstanceID.add(1, ordering: .relaxed).oldValue }
 
-    var discoveryManager: DiscoveryManager
+    let discoveryManager: DiscoveryManager
     private var syncCallManager: SyncCallManager
     var compressionMode: CompressionMode
 
@@ -798,7 +799,9 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
         }
     }
 
-    private func actorsForChannelLocked(_ channelID: UInt32) -> [(EndpointIdentifier, AsyncStream<InvocationEnvelope>.Continuation, ManagedAtomic<UInt64>)] {
+    private func actorsForChannelLocked(
+        _ channelID: UInt32
+    ) -> [(EndpointIdentifier, AsyncStream<InvocationEnvelope>.Continuation, ManagedAtomic<UInt64>)] {
         // lock supposed to be locked by the caller
         var actors = [(EndpointIdentifier, AsyncStream<InvocationEnvelope>.Continuation, ManagedAtomic<UInt64>)]()
         for (actorID, actorInfo) in self.actors {
@@ -978,8 +981,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
                     case .remoteClient:
                         let (stream, continuation) = AsyncStream.makeStream(of: InvocationEnvelope.self)
                         let queueSize = ManagedAtomic<UInt64>(0)
-                        let sfrc = ActorInfo.Inbound(continuation, queueSize)
-                        self.actors[actor.id] = .serviceForRemoteClient(sfrc)
+                        self.actors[actor.id] = .serviceForRemoteClient(.init(continuation, queueSize))
                         if let channelInfo = self.channels[actor.id.channelID] {
                             let channelAddressDescription = channelInfo.channel.addressDescription
                             Task { await self.streamTask(stream, actor.id, actor, channelInfo.channel, channelAddressDescription, queueSize) }
@@ -1002,8 +1004,7 @@ public class DistributedSystem: DistributedActorSystem, @unchecked Sendable {
                 } else if let channelInfo = self.channels[channelID] {
                     let (stream, continuation) = AsyncStream.makeStream(of: InvocationEnvelope.self)
                     let queueSize = ManagedAtomic<UInt64>(0)
-                    let cfrs = ActorInfo.Inbound(continuation, queueSize)
-                    self.actors[actor.id] = .clientForRemoteService(cfrs)
+                    self.actors[actor.id] = .clientForRemoteService(.init(continuation, queueSize))
                     let channelAddressDescription = channelInfo.channel.addressDescription
                     Task { await self.streamTask(stream, actor.id, actor, channelInfo.channel, channelAddressDescription, queueSize) }
                 } else {


### PR DESCRIPTION
## Description

Include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
